### PR TITLE
protocol/westworld3: fix dropped error

### DIFF
--- a/protocol/westworld3/message.go
+++ b/protocol/westworld3/message.go
@@ -85,6 +85,9 @@ func newHello(seq int32, h hello, a *ack, p *pool) (wm *wireMessage, err error) 
 		}
 	}
 	helloSz, err = encodeHello(h, wm.buffer.data[dataStart+acksSz:])
+	if err != nil {
+		return nil, errors.Wrap(err, "error encoding hello")
+	}
 	return wm.encodeHeader(uint16(acksSz + helloSz))
 }
 


### PR DESCRIPTION
This fixes an `err` variable that was being swallowed.