### PR TITLE
protocol/westworld2: prune dead code

### DIFF
--- a/protocol/westworld2/config.go
+++ b/protocol/westworld2/config.go
@@ -289,5 +289,3 @@ func (self *Config) Dump() string {
 	out += "}"
 	return out
 }
-
-const treeReportCt = 1000

--- a/protocol/westworld2/message.go
+++ b/protocol/westworld2/message.go
@@ -4,7 +4,6 @@ import (
 	"github.com/openziti/dilithium/util"
 	"github.com/pkg/errors"
 	"net"
-	"strings"
 )
 
 type wireMessage struct {
@@ -184,14 +183,6 @@ type messageFlag uint8
 const (
 	RTT messageFlag = 1
 )
-
-func (self messageFlag) string() string {
-	out := ""
-	if self|RTT == 1 {
-		out += " RTT"
-	}
-	return strings.TrimSpace(out)
-}
 
 const (
 	headerSz = 12


### PR DESCRIPTION
This removes an unused constant, an unused function and its import of `string`.